### PR TITLE
Add workaround of SVN-3978 for `POST photos:filter`

### DIFF
--- a/Photos API/ACC Photos API.postman_collection.json
+++ b/Photos API/ACC Photos API.postman_collection.json
@@ -187,12 +187,13 @@
 					{
 						"key": "Accept-Encoding",
 						"value": "gzip, deflate",
-						"type": "text"
+						"type": "text",
+						"disabled": true
 					}
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{}"
+					"raw": "{\n    \"sort\": [\"createdAt\", \"asc\"]\n}"
 				},
 				"url": {
 					"raw": "{{base_domain}}construction/photos/v1/projects/:projectId/photos:filter",
@@ -261,7 +262,8 @@
 					{
 						"key": "Accept-Encoding",
 						"value": "gzip, deflate",
-						"type": "text"
+						"type": "text",
+						"disabled": true
 					}
 				],
 				"url": {


### PR DESCRIPTION
I am adding a workaround to prevent customers from running into SVN-3978.