### PR TITLE
Remove the workaround of SVN-3978 after releasing the fix

### DIFF
--- a/Photos API/ACC Photos API.postman_collection.json
+++ b/Photos API/ACC Photos API.postman_collection.json
@@ -187,7 +187,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n    \"sort\": [\"createdAt\", \"asc\"]\n}"
+					"raw": "{\n    \n}"
 				},
 				"url": {
 					"raw": "{{base_domain}}construction/photos/v1/projects/:projectId/photos:filter",

--- a/Photos API/README.md
+++ b/Photos API/README.md
@@ -14,10 +14,6 @@ This folder contains a Postman Collection that includes all the current ACC Phot
 
 ![Collection](img/collection.png)
 
-### Known issue
-
-- When you're calling POST photos:filter, you will need to add a sort filter in the body, e.g., `{ "sort": ["createdAt", "asc"] }`. Otherwise, the call will be failed, if you have more than 25 photos. (**SVN-3978**)
-
 
 ## Instructions to run the Postman collection are as below:
 


### PR DESCRIPTION
- Remove the `known issue` section from the README.md.
- Remove the workaround of SVN-3978 from the Postman collection.